### PR TITLE
Handle giveaway popups only with unmodified left click

### DIFF
--- a/SGPP/Modules/PopupGiveaway.ts
+++ b/SGPP/Modules/PopupGiveaway.ts
@@ -30,9 +30,11 @@ module ModuleDefinition {
         }
 
         private handlePopupCreate = (dom) => {
-            $('a[href^="/giveaway/"]:not([href$="/entries"],[href$="/comments"],[href$="/winners"],[href$="/groups"])', dom).on("click",(e) => {
-                e.preventDefault();
-                this.handlePopup($(e.currentTarget));
+            $('a[href^="/giveaway/"]:not([href$="/entries"],[href$="/comments"],[href$="/winners"],[href$="/groups"])', dom).on("click", (e) => {
+                if (e.button === 0 && !(e.ctrlKey || e.shiftKey || e.altKey)) {
+                    e.preventDefault();
+                    this.handlePopup($(e.currentTarget));
+                }
             });
         }
 


### PR DESCRIPTION
Handle giveaway popups only with left click with no modifier keys.

In Chrome, this re-enables opening GA pages in a new tab with a middle
click.
In Chrome and Firefox, this re-enables standard modifier keys. (CTRL:
open in new tab, SHIFT: open in new window)
